### PR TITLE
Fixing bug where a failed connection would cause a crash

### DIFF
--- a/Android/app/src/main/java/kazahkstan/gpsclient/MainActivity.java
+++ b/Android/app/src/main/java/kazahkstan/gpsclient/MainActivity.java
@@ -196,7 +196,7 @@ public class MainActivity extends AppCompatActivity {
 -----------------------------------------------------------------------------------*/
     protected void getData(Location location) {
         String gpsData = localIP + " " + location.getLatitude() + " " + location.getLongitude();
-    if (tcp != null)
+    if (tcp.gpsON != false)
         try {
             sendData(gpsData);
         } catch (IOException e) {


### PR DESCRIPTION
Forgot that the actual connection was a member of TCP, not tcp itself.
Using the Boolean that only gets set to true if we succeed as the check instead.